### PR TITLE
Add units option to the API call

### DIFF
--- a/forecastio.class.nut
+++ b/forecastio.class.nut
@@ -34,11 +34,12 @@ class Forecastio {
         _apikey = key;
     }
 
-    function forecastRequest(longitude = 999, latitude = 999, callback = null) {
+    function forecastRequest(longitude = 999, latitude = 999, units = us, callback = null) {
         // Parameters:
         //  1. Longitude of location for which a forecast is required
         //  2. Latitude of location for which a forecast is required
-        //  3. Optional synchronous operation callback
+        //  3. Optional units parameter which defaults to us is not specified
+        //  4. Optional synchronous operation callback
         // Returns:
         //  If callback is null, the function returns a table with key 'response'
         //  If callback is not null, the function returns nothing
@@ -53,16 +54,17 @@ class Forecastio {
             }
         }
 
-        local url = FORECAST_URL + _apikey + "/" + format("%.6f", latitude) + "," + format("%.6f", longitude);
+        local url = FORECAST_URL + _apikey + "/" + format("%.6f", latitude) + "," + format("%.6f", longitude) + "?units=" + units;
         return _sendRequest(http.get(url), callback);
     }
 
-    function timeMachineRequest(longitude = 999, latitude = 999, time = null, callback = null) {
+    function timeMachineRequest(longitude = 999, latitude = 999, time = null, units = us, callback = null) {
         // Parameters:
         //  1. Longitude of location for which a forecast is required
         //  2. Latitude of location for which a forecast is required
         //  3. A Unix time or ISO 1601-formatted string
-        //  4. Optional synchronous operation callback
+        //  4. Optional units parameter which defaults to us is not specified
+        //  5. Optional synchronous operation callback
         // Returns:
         //  If callback is null, the function returns a table with key 'response'
         //  If callback is not null, the function returns nothing
@@ -92,7 +94,7 @@ class Forecastio {
             return {"err": "Timestamp error"};
         }
 
-        local url = FORECAST_URL + _apikey + "/" + format("%.6f", latitude) + "," + format("%.6f", longitude) + "," + timeString;
+        local url = FORECAST_URL + _apikey + "/" + format("%.6f", latitude) + "," + format("%.6f", longitude) + "," + timeString + "?units=" + units;
         return _sendRequest(http.get(url), callback);
     }
 

--- a/forecastio.class.nut
+++ b/forecastio.class.nut
@@ -15,6 +15,7 @@ class Forecastio {
 
     static FORECAST_URL = "https://api.forecast.io/forecast/";
     static VERSION = [1,0,0];
+    static VALID_UNITS = [us,si,ca,uk2,auto];
 
     _apikey = null;
     _debug = false;
@@ -38,7 +39,7 @@ class Forecastio {
         // Parameters:
         //  1. Longitude of location for which a forecast is required
         //  2. Latitude of location for which a forecast is required
-        //  3. Optional units parameter which defaults to us is not specified
+        //  3. Units parameter which defaults to us if improperly specified
         //  4. Optional synchronous operation callback
         // Returns:
         //  If callback is null, the function returns a table with key 'response'
@@ -53,7 +54,11 @@ class Forecastio {
                 return {"err": "Co-ordinate error"};
             }
         }
-
+        
+        if (!(units in VALID_UNITS)) {
+            units = us;
+        }
+        
         local url = FORECAST_URL + _apikey + "/" + format("%.6f", latitude) + "," + format("%.6f", longitude) + "?units=" + units;
         return _sendRequest(http.get(url), callback);
     }
@@ -63,7 +68,7 @@ class Forecastio {
         //  1. Longitude of location for which a forecast is required
         //  2. Latitude of location for which a forecast is required
         //  3. A Unix time or ISO 1601-formatted string
-        //  4. Optional units parameter which defaults to us is not specified
+        //  4. Units parameter which defaults to us if improperly specified
         //  5. Optional synchronous operation callback
         // Returns:
         //  If callback is null, the function returns a table with key 'response'
@@ -84,6 +89,10 @@ class Forecastio {
             return {"err": "Timestamp error"};
         }
 
+        if (!(units in VALID_UNITS)) {
+            units = us;
+        }
+        
         local timeString;
         if (typeof time == "integer") {
             timeString = time.tostring();


### PR DESCRIPTION
Forecast.io supports receiving their data in multiple unit formats (us being the default).  It would be handy to receive the data in the proper units instead of having to convert everything by hand.
