### PR TITLE
Update readme to reference the units parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ fc <- Forecastio(API_KEY);
 
 ## Class Methods
 
-### forecastRequest(*longitude, latitude[, callback]*)
+### forecastRequest(*longitude, latitude, units[, callback]*)
 
 This method sends a [forecast request](https://developer.forecast.io/docs/v2#forecast_call) to the Forecast API using the co-ordinates passed into the parameters *longitude* and *latitude*.
+
+You can pass a units parameter which will return the data from the API in the units desired.
+Valid entries include: us (the default/fallback), si, ca, uk2, auto
+see https://developer.forecast.io/docs/v2#options for more infomation.
 
 You can pass an optional callback function: if you do, the forecast request will be made asynchronously and the callback executed with the returned data. Your callback function must include two parameters: *err*, into which a human-readable error message error message will passed if an error was encountered during the assembly or sending of the request; and *data*, a table containing the decoded response from Forecast.io.
 
@@ -41,7 +45,7 @@ The data returned by the Forecast API is complex and is not parsed in any way by
 #### Example
 
 ```squirrel
-fc.forecastRequest(myLongitude, myLatitude, function(err, data) {
+fc.forecastRequest(myLongitude, myLatitude, units, function(err, data) {
     if (err) server.error(err);
 
     if (data) {
@@ -67,9 +71,13 @@ fc.forecastRequest(myLongitude, myLatitude, function(err, data) {
 });
 ```
 
-### timeMachineRequest(*longitude, latitude, time[, callback]*)
+### timeMachineRequest(*longitude, latitude, time, units[, callback]*)
 
 This method sends a [time machine request](https://developer.forecast.io/docs/v2#time_call) to the Forecast API using the co-ordinates passed into the parameters *longitude* and *latitude*, and a timestamp. The value passed into the parameter *time* should be either a Unix timestamp (an Integer) or a string formatted according to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601).
+
+You can pass a units parameter which will return the data from the API in the units desired.
+Valid entries include: us (the default/fallback), si, ca, uk2, auto
+see https://developer.forecast.io/docs/v2#options for more infomation.
 
 You can pass an optional callback function: if you do, the forecast request will be made asynchronously and the callback executed with the returned data. Your callback function must include two parameters: *err*, into which a human-readable error message error message will passed if an error was encountered during the assembly or sending of the request; and *data*, a table containing the decoded response from Forecast.io.
 
@@ -81,7 +89,7 @@ The data returned by the Forecast API is complex and is not parsed in any way by
 
 ```squirrel
 local monthAgo = time() - 2592000;
-fc.timeMachineRequest(myLongitude, myLatitude, monthAgo, function(err, data) {
+fc.timeMachineRequest(myLongitude, myLatitude, monthAgo, units, function(err, data) {
     if (err) server.error(err);
 
     if (data) {


### PR DESCRIPTION
I had originally thought that the units parameter could be optional but then realized that there would be no way to easily know if the 3rd parameter (or 4th in the case of a timemachine request) was units or a callback.  So units should probably be mandatory.

I will make a change to the nut file so that it checks for valid units and falls back to "us" if a valid unit is not supplied.  This will make the update backward compatible (except in the case where a callback is expected).
